### PR TITLE
Set user user_agent_*_var to empty string in case it's nil

### DIFF
--- a/lua/anti_ddos_challenge.lua
+++ b/lua/anti_ddos_challenge.lua
@@ -346,7 +346,7 @@ If you want to block access to bad bots / specific user-agents you can use this.
 
 I added some examples of bad bots to block access to.
 ]]
-local user_agent_blacklist_var = ngx.var.http_user_agent
+local user_agent_blacklist_var = ngx.var.http_user_agent or ""
 local user_agent_blacklist_table = {
 	{
 		"^$",
@@ -392,7 +392,7 @@ If you want to allow access to specific user-agents use this.
 
 I added some examples of user-agents you could whitelist mostly search engine crawlers.
 ]]
-local user_agent_whitelist_var = ngx.var.http_user_agent
+local user_agent_whitelist_var = ngx.var.http_user_agent or ""
 local user_agent_whitelist_table = {
 --[[
 	{


### PR DESCRIPTION
If no user agent is sent ngx.var.http_user_agent is nil which leads to multiple errors because the code expects user_agent_*_var to be a string. This addresses the same as  #55 but should be more robust.